### PR TITLE
Model Metadata YAML Validation

### DIFF
--- a/examples/mlm-metadata.yaml
+++ b/examples/mlm-metadata.yaml
@@ -1,0 +1,39 @@
+name: Unet
+architecture: Unet
+artifact_type: torch.export.save
+framework: torch
+framework_version: 2.7.0
+accelerator: cuda
+total_parameters: 1234567
+tasks: [semantic-segmentation]
+input:
+  - name: Imagery
+    bands: [red, blue, green]
+    input:
+      shape: [-1, 3, 512, 512]
+      dim_order: [batch, channel, height, width]
+      data_type: float32
+      res: 0.1
+    pre_processing_function:
+      format: pt2-exported-program
+      expression: transforms
+output:
+  - name: segmentation-output
+    tasks: ["semantic-segmentation"]
+    result:
+      shape: [-1, 6, 512, 512]
+      dim_order: [batch, classes, height, width]
+      data_type: float32
+    classification:classes:
+      - value: 0
+        name: Class 0
+      - value: 1
+        name: Class 1
+      - value: 2
+        name: Class 2
+      - value: 3
+        name: Class 3
+      - value: 4
+        name: Class 4
+      - value: 5
+        name: Class 5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pystac
 import pytest
+import yaml
 
 from stac_model.base import JSON
 from stac_model.examples import eurosat_resnet as make_eurosat_resnet
@@ -60,7 +61,12 @@ def mlm_validator(
 @pytest.fixture
 def mlm_example(request: "SubRequest") -> dict[str, JSON]:
     with open(os.path.join(EXAMPLES_DIR, request.param)) as example_file:
-        data = json.load(example_file)
+        if request.param.endswith(".json"):
+            data = json.load(example_file)
+        elif request.param.endswith(".yaml"):
+            data = yaml.safe_load(example_file)
+        else:
+            raise ValueError(f"Unsupported file format for example: {request.param}")
     return cast(dict[str, JSON], data)
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,7 @@ from jsonschema.exceptions import ValidationError
 from pystac.validation.stac_validator import STACValidator
 
 from stac_model.base import JSON
-from stac_model.schema import SCHEMA_URI
+from stac_model.schema import SCHEMA_URI, MLModelProperties
 
 from conftest import get_all_stac_item_examples
 
@@ -353,3 +353,12 @@ def test_collection_include_all_items(mlm_example):
     col_items = {os.path.basename(link["href"]) for link in col_links if link["rel"] == "item"}
     all_items = {os.path.basename(path) for path in get_all_stac_item_examples()}
     assert all_items == col_items, "Missing STAC Item examples in the example STAC Collection links."
+
+
+@pytest.mark.parametrize(
+    "mlm_example",
+    ["mlm-metadata.yaml"],
+    indirect=True,
+)
+def test_mlm_metadata_only_yaml_validation(mlm_example):
+    MLModelProperties.model_validate(mlm_example)


### PR DESCRIPTION
## Description

Adding an example yaml of only the ML model metadata only minus the STAC required components. This can be validated using the pydantic classes like so:

```python
import yaml
from stac_model.schema import MLModelProperties

with open("examples/mlm-metadata.yaml", "r") as f:
    metadata = yaml.safe_load(f)

MLModelProperties.model_validate(metadata)  # validates that the required metadata fields are filled out and the correct types
```

## Related Issue

N/A

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [X] I've updated the code style using `make check`;
- [X] I've written tests for all new methods and classes that I created;
- [X] I've written the docstring in `Google` format for all the methods and classes that I used.
